### PR TITLE
[PR] Bump version 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wsuwp-content-syndicate-people",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/washingtonstateuniversity/wsuwp-content-syndicate-people"

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@ Plugin URI: https://web.wsu.edu/wordpress/plugins/wsuwp-content-syndicate/
 Description: Retrieve people for display from people.wsu.edu.
 Author: washingtonstateuniversity, jeremyfelt
 Author URI: https://web.wsu.edu/
-Version: 1.0.1
+Version: 1.0.2
 */
 
 namespace WSU\ContentSyndicate\People;


### PR DESCRIPTION
This should maybe be a minor release, but is technically more of a bug fix since the `host` attribute was already available.